### PR TITLE
Fix spanner.RowIterator Stop detection in test files

### DIFF
--- a/internal/config/rules.yaml
+++ b/internal/config/rules.yaml
@@ -136,7 +136,7 @@ package_exceptions:
     condition:
       type: "test"
       description: "テストコード例外"
-      enabled: true
+      enabled: false
 
 # 診断レベル制御設定
 diagnostics:


### PR DESCRIPTION
## Summary
Fix missing detection of spanner.RowIterator Stop() calls in test files, enabling proper resource leak detection for Query/Read patterns.

## Problem
- RowIterator Stop() leaks were not detected in `*_test.go` files
- Test file exception was enabled by default, preventing analysis of test code
- Real-world patterns like `iter := client.Query()` without `iter.Stop()` were missed

## Solution
- **Disable test file exception**: Set `enabled: false` for `*_test.go` pattern in `rules.yaml`
- **Enhanced test coverage**: Added comprehensive RowIterator test cases
- **Improved mock setup**: Added proper type information for `iter` variables

## Verification
Tested on real KultureJP project files and successfully detected:
```
/path/to/client_test.go:40:12: GCP リソース 'iter' の解放処理 (Stop) が見つかりません
/path/to/client_test.go:71:11: GCP リソース 'iter' の解放処理 (Stop) が見つかりません  
/path/to/client_test.go:91:12: GCP リソース 'iter' の解放処理 (Stop) が見つかりません
```

## Changes
- `internal/config/rules.yaml`: Disable test file exception (`enabled: true` → `false`)
- Enhanced test cases for RowIterator patterns (previous commits)
- Improved resource tracking for Query/Read method calls (previous commits)

## Test Plan
- [x] Local verification with KultureJP project files
- [x] All existing tests pass
- [x] RowIterator Stop detection now works in test files
- [x] No regression in other detection capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)